### PR TITLE
Send the logs to Loggly

### DIFF
--- a/src/LogglyBulkLogger.php
+++ b/src/LogglyBulkLogger.php
@@ -99,7 +99,7 @@ final class LogglyBulkLogger extends AbstractLogglyLogger
                 'Content-Type' => 'application/json',
                 'Content-Length' => strlen($data),
             ],
-            '1.1'
+            $data
         );
     }
 }

--- a/src/LogglyLogger.php
+++ b/src/LogglyLogger.php
@@ -41,7 +41,7 @@ final class LogglyLogger extends AbstractLogglyLogger
                 'Content-Type' => 'application/json',
                 'Content-Length' => strlen($data),
             ],
-            '1.1'
+            $data
         );
     }
 }


### PR DESCRIPTION
The initial refactoring contained a bug that would send the HTTP version to logly, not the log lines it is supposed to.